### PR TITLE
Added try-catch block when reading block by ((UUID)) to prevent unwarranted errors

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -314,16 +314,20 @@ async function formatText(text2, template) {
   const rxGetId = /\(\(([^)]*)\)\)/;
   const blockId = rxGetId.exec(text);
   if (blockId != null) {
-    const block = await logseq.Editor.getBlock(blockId[1], {
-      includeChildren: true,
-    });
-    //optional based on setting enabled
+    try {
+      const block = await logseq.Editor.getBlock(blockId[1], {
+        includeChildren: true,
+      });
+      //optional based on setting enabled
 
-    if (block != null) {
-      text = text.replace(
-        `((${blockId[1]}))`,
-        block.content.substring(0, block.content.indexOf("id::"))
-      );
+      if (block != null) {
+        text = text.replace(
+          `((${blockId[1]}))`,
+          block.content.substring(0, block.content.indexOf("id::"))
+        );
+      }
+    } catch(e) {
+      console.log(e);
     }
   }
 


### PR DESCRIPTION
Just added a simple try-catch block. Fixes #49 