### PR TITLE
Add Download button above pdf preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # logseq-pdf-export
 >If this plugin helps you, I'd really appreciate your support. You can [buy me a coffee here. ](https://www.buymeacoffee.com/sawhney17)
 
-A plugin to export the current page as your *own* custom styled pdf, 
+A plugin to export the current page as your *own* custom styled pdf.
 ## Instructions
-1. Click the button in the toolbar
+1. Click the plugin button in the toolbar
 2. Select the template you want the pdf to follow
     - You can configure templates in settings
 3. Check the preview of your pdf
-4. Click "download pdf" to download it
+4. Click "Download" to download the pdf
 
 ## Recommended Settings
 <img width="873" alt="Screen Shot 2022-04-07 at 9 40 26 AM" src="https://user-images.githubusercontent.com/80150109/162128157-93e0bd3a-7df4-4f0b-976b-64dc528968fc.png">
-- You can customize it further by inserting CSS or use logseqs custom.css feature
+- You can customize it further by inserting CSS or using logseq's custom.css feature.
 
 ## Support
 1. Markdown Tables
 2. Most basic formatting
 3. Parses block references
 4. Can remove properties and brackets
-5. Can Inherit current logseq theme!!!
-6. Custom.css support
+5. Can inherit current logseq theme!!!
+6. Supports using logseq `custom.css` file
 
 ## Credits
-- thanks to [@supery-chen](https://github.com/supery-chen?tab=repositories) for the implementation which retains _all_ formatting. YOU ROCK! 🎉
+- Thanks to [@supery-chen](https://github.com/supery-chen?tab=repositories) for the implementation which retains _all_ formatting. YOU ROCK! 🎉
 ---
-<a href="https://www.flaticon.com/free-icons/pdf" title="pdf icons">Pdf icons created by Dimitry Miroliubov - Flaticon</a>
+<a href="https://www.flaticon.com/free-icons/pdf" title="pdf icons">pdf icons created by Dimitry Miroliubov - Flaticon</a>

--- a/src/App3.tsx
+++ b/src/App3.tsx
@@ -28,6 +28,7 @@ const App3: React.FC<{htmlText}> = ({htmlText}) => {
       <div className="bg-slate-400 z-30 rounded-2xl p-4">
       
         <h1 className="font-bold text-4xl" >PDF Preview</h1>
+        <div className=''><button className='button' onClick={() => downloadBulletLess()}>Download</button></div>
         <br></br>
         <div dangerouslySetInnerHTML={{__html: htmlText}} id = "cooldiv" className='bg-white rounded-xl'></div> 
         <br></br>


### PR DESCRIPTION
This pull request adds a "**Download**" button above the PDF preview to allow download without having to scroll through the rendered document.

The pull request also makes two fairly trivial changes: removing what appears to be an unnecessary file `Untitled-1` in the project root; and making a few small typographical modifications to `README.md`.